### PR TITLE
add_results in pipe and get_results fixed for all successes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ LazyData: TRUE
 RoxygenNote: 7.1.0
 Imports:
     shiny,
-    shiny.semantic,
+    shiny.semantic (>= 0.3.3),
     knitr,
     purrr,
     dplyr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: data.validator
 Type: Package
 Title: Tools for automatic validation report
-Version: 0.1.1
+Version: 0.1.2
 Organization: Appsilon Data Science
 Author: Michal Maj <michal@appsilon.com>
 Maintainer: Dominik Krzeminski <filip@appsilondatascience.com>

--- a/R/semantic_report_constructors.R
+++ b/R/semantic_report_constructors.R
@@ -22,7 +22,7 @@ prepare_modal_content <- function(error) {
       htmltools::div(style = "padding-left: 1em;",
                  htmltools::div(class = "ui header", "Violated data (sample)"),
                  htmltools::HTML(knitr::kable(utils::head(error$error_df[[1]][[.x]]), "html", align = NULL, table.attr = "class=\"ui cellable table\"")),
-                 htmltools::div(class = "ui horizontal divider", shiny.semantic::uiicon("flag"))
+                 htmltools::div(class = "ui horizontal divider", shiny.semantic::icon("flag"))
       )
     htmltools::tagList(
       htmltools::tags$table(class = "ui definition table",
@@ -81,7 +81,7 @@ make_table_row <- function(results, type, mark) {
                    htmltools::tags$h6(description)
     ),
     htmltools::tags$td(class = "center aligned",
-                   shiny.semantic::uiicon(mark)
+                   shiny.semantic::icon(mark)
     ),
     htmltools::tags$td(class = "center aligned",
                    htmltools::tagList(
@@ -145,8 +145,8 @@ make_accordion_element <- function(results, color = "green", label, active = FAL
     state <- "active"
   }
   htmltools::tagList(
-    htmltools::div(class = paste("title", state), shiny.semantic::uiicon("dropdown"),
-               htmltools::tagList(shiny.semantic::uilabel(length(unique(results$assertion.id)), type = paste(color, "circular tiny")), label)),
+    htmltools::div(class = paste("title", state), shiny.semantic::icon("dropdown"),
+               htmltools::tagList(shiny.semantic::label(length(unique(results$assertion.id)), type = paste(color, "circular tiny")), label)),
     htmltools::div(class = paste("content", state), result_table(results, type, mark))
   )
 }
@@ -216,7 +216,7 @@ display_results <- function(data, n_passes, n_fails, n_warns) {
 create_summary_row <- function(id, number, color, label) {
   list(htmltools::tags$td(id = id,
                  class = "two wide right aligned",
-                 shiny.semantic::uilabel(number, type = paste(color, "circular huge"))),
+                 shiny.semantic::label(number, type = paste(color, "circular huge"))),
   htmltools::tags$td(class = "three wide left aligned", htmltools::tags$h2(label)))
 }
 

--- a/R/semantic_report_constructors.R
+++ b/R/semantic_report_constructors.R
@@ -145,8 +145,13 @@ make_accordion_element <- function(results, color = "green", label, active = FAL
     state <- "active"
   }
   htmltools::tagList(
-    htmltools::div(class = paste("title", state), shiny.semantic::icon("dropdown"),
-               htmltools::tagList(shiny.semantic::label(length(unique(results$assertion.id)), type = paste(color, "circular tiny")), label)),
+    htmltools::div(
+      class = paste("title", state), shiny.semantic::icon("dropdown"),
+      htmltools::tagList(
+        shiny.semantic::label(length(unique(results$assertion.id)), class = paste(color, "circular tiny"), is_link = FALSE),
+        label
+      )
+    ),
     htmltools::div(class = paste("content", state), result_table(results, type, mark))
   )
 }
@@ -216,7 +221,7 @@ display_results <- function(data, n_passes, n_fails, n_warns) {
 create_summary_row <- function(id, number, color, label) {
   list(htmltools::tags$td(id = id,
                  class = "two wide right aligned",
-                 shiny.semantic::label(number, type = paste(color, "circular huge"))),
+                 shiny.semantic::label(number, class = paste(color, "circular huge"), is_link = FALSE)),
   htmltools::tags$td(class = "three wide left aligned", htmltools::tags$h2(label)))
 }
 

--- a/R/validator.R
+++ b/R/validator.R
@@ -59,7 +59,8 @@ Validator <- R6::R6Class(
         params = list(
           generate_report_html = self$generate_html_report,
           extra_params = list(...)
-        )
+        ),
+        quiet = TRUE
       )
     },
     save_log = function(file_name = "validation_log.txt", success, warning, error) {

--- a/R/validator.R
+++ b/R/validator.R
@@ -34,6 +34,10 @@ Validator <- R6::R6Class(
     get_validations = function(unnest = FALSE) {
       validation_results = private$validation_results
       if (unnest) {
+        if (all(purrr::map_lgl(validation_results$error_df, is.null))) {
+          validation_results$error_df <- NULL
+          return(validation_results)
+        }
         validation_results <- validation_results %>%
           tidyr::unnest(error_df, keep_empty = TRUE)
       }

--- a/R/validator.R
+++ b/R/validator.R
@@ -29,7 +29,7 @@ Validator <- R6::R6Class(
       private$n_warned <- sum(private$n_warned, n_results[warning_id], na.rm = TRUE)
       private$n_passed <- sum(private$n_passed, n_results[success_id], na.rm = TRUE)
       private$validation_results <- dplyr::bind_rows(private$validation_results, results)
-      invisible(self)
+      invisible(data)
     },
     get_validations = function(unnest = FALSE) {
       validation_results = private$validation_results

--- a/examples/minimal_example/example.R
+++ b/examples/minimal_example/example.R
@@ -1,6 +1,7 @@
 library(readr)
 library(assertr)
 library(data.validator)
+library(dplyr)
 
 # Data comes from tidy tuesday
 beer_states <- readr::read_csv('https://raw.githubusercontent.com/rfordatascience/tidytuesday/master/data/2020/2020-03-31/beer_states.csv')


### PR DESCRIPTION
`add_results` was useful only to be applied at the end of the pipe.
In some cases (like before aggreagation), you may want to make it in the middle step:

```
data %>%
  assert(...) %>%
  add_results(validator, name = "data") %>%
  group_by(...) %>%
  summarise(...) %>%
  add_results(validator, name = "data aggreagted")
```

This simple PR enables such option.

More to that `get_results(unnest = TRUE)` crashed when data stored only successes.