### PR TITLE
chore: Add link to Mastodon.

### DIFF
--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -34,6 +34,8 @@ navbar:
       href: https://github.com/Appsilon/data.validator
     - icon: fa-twitter fa-lg
       href: https://twitter.com/Appsilon
+    - icon: fab fa-mastodon fa-lg
+      href: https://fosstodon.org/@appsilon
 
 home:
   sidebar:


### PR DESCRIPTION
Add a link to the Appsilon profile on Mastodon.
