### PR TITLE
Fix shiny semantic accordion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ Imports:
     rlang,
     rmarkdown,
     htmltools,
-    htmlwidgets,
     tibble
 Suggests:
     covr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: data.validator
 Type: Package
 Title: Automatic Data Validation and Reporting
-Version: 0.1.7
+Version: 0.1.7.9000
 Authors@R: c(person("Krystian", "Igras", email = "krystian@appsilon.com", role = c("aut")),
              person("Marcin", "Dubel", email = "marcin@appsilon.com", role = c("aut", "cre")),
              person("Paweł", "Przytuła", email = "pawel@appsilon.com", role = c("aut")),

--- a/R/semantic_report_constructors.R
+++ b/R/semantic_report_constructors.R
@@ -314,17 +314,13 @@ get_semantic_report_ui <- function(n_passes, n_fails, n_warns, validation_result
         display_results(n_passes, n_fails, n_warns)
     }) %>%
     htmltools::div()
-  htmltools::div(summary_table, html_report)
+  htmltools::div(
+    summary_table,
+    html_report,
+    onmouseover = "setTimeout(function() {$('.ui.accordion').accordion()}, 500);
+      this.onmouseover = null;"
+  )
 }
-
-post_render_js <- "
-  function activateAccordion() {
-    $('.ui.accordion').accordion();
-  }
-  $(window).on('load', function () {
-    activateAccordion();
-  });
-"
 
 #' Render semantic version of report
 #'
@@ -353,10 +349,7 @@ render_semantic_report_ui <- function(validation_results,
   )
   get_semantic_report_ui(n_passes, n_fails, n_warns,
                        validation_results) %>%
-    shiny.semantic::uirender(width = "100%", height = "100%") %>%
-    htmltools::tagList(
-      htmlwidgets::onStaticRenderComplete(post_render_js)
-    )
+    shiny.semantic::uirender(width = "100%", height = "100%")
 }
 
 #' Render simple version of report


### PR DESCRIPTION
In the shiny version of the semantic report, the accordion was not working (the JS code was never executed). This PR replaces the previous solution with an "onmouseover" event (triggered only once).

To test try creating example reports:
https://github.com/Appsilon/data.validator/tree/main/examples/shiny_app
https://github.com/Appsilon/data.validator/tree/main/examples/minimal_example