### PR TITLE
fix: Remove deprecated .data calls.

### DIFF
--- a/R/results_parsers.R
+++ b/R/results_parsers.R
@@ -109,7 +109,7 @@ parse_results_to_df <- function(data) {
 #' @keywords internal
 get_results_number <- function(results) {
   results %>%
-    dplyr::select(.data$assertion.id, .data$type) %>%
+    dplyr::select("assertion.id", "type") %>%
     dplyr::distinct() %>%
     dplyr::pull(.data$type) %>%
     table()

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
 library(data.validator)
 
-test_check("data.validator")
+test_check("data.validator", stop_on_warning = TRUE)


### PR DESCRIPTION
Remove softly deprecated `.data` calls in `select`. More details can be found [here](https://www.tidyverse.org/blog/2022/10/tidyselect-1-2-0/#using-data-inside-selections).