### PR TITLE
Tanesya.add unit tests

### DIFF
--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -16,6 +16,22 @@ test_that("get_assert_method correctly choses assertion method", {
   )
 })
 
+test_that("predicate in get_assert_method expects function returning logical vector or function", {
+  predicate <- function(x) x + 1
+  expect_error(data.validator:::get_assert_method(predicate))
+})
+
+test_that("validate returns expected attributes", {
+  data <- data.frame(V1 = c("c", "d"), V2 = c(2, 2), V3 = c(1, 1))
+  data <- validate(data, description = "Validation object description test")
+  attr_names <- names(attributes(data))
+
+  expect_true("data-name" %in% attr_names)
+  expect_true("data-description" %in% attr_names)
+  expect_true("assertr_in_chain_success_fun_override" %in% attr_names)
+  expect_true("assertr_in_chain_error_fun_override" %in% attr_names)
+})
+
 test_that("Validation works even with evaluation error", {
   validation_result <-
     data.validator::validate(iris, name = "Iris wrong column test") %>%
@@ -69,4 +85,17 @@ test_that("validate_rows throws a message if there are no columns selected", {
   validation <- validate(data)
 
   expect_message(validate_rows(validation, rowSums, function(x) TRUE))
+})
+
+test_that("validate_if correctly handles validation", {
+  data <- data.frame(
+    V1 = c(1, 0),
+    V2 = c(-1, -2)
+  )
+
+  val_success <- validate_if(data, V2 < 0)
+  val_error <- validate_if(data, V1 < 0)
+
+  expect_true(success_class %in% names(attributes(val_success)))
+  expect_true("assertr_errors" %in% names(attributes(val_error)))
 })

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -83,6 +83,9 @@ test_that("validate_rows throws a message if there are no columns selected", {
 })
 
 test_that("validation returns assert_success or assert_errors attribute based on result", {
+  name_success  <- "assertr_success"
+  name_error  <- "assertr_errors"
+
   data <- data.frame(
     V1 = c(1, 0),
     V2 = c(-1, -2)
@@ -92,6 +95,9 @@ test_that("validation returns assert_success or assert_errors attribute based on
   val_success <- validate_if(data, V2 < 0)
   val_error <- validate_if(data, V1 < 0)
 
-  expect_true("assertr_success" %in% names(attributes(val_success)))
-  expect_true("assertr_errors" %in% names(attributes(val_error)))
+  expect_true(name_success %in% names(attributes(val_success)))
+  expect_false(name_error %in% names(attributes(val_success)))
+  expect_true(name_error %in% names(attributes(val_error)))
+  expect_false(name_success %in% names(attributes(val_error)))
 })
+

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -82,7 +82,7 @@ test_that("validate_rows throws a message if there are no columns selected", {
   expect_message(validate_rows(validation, rowSums, function(x) TRUE))
 })
 
-test_that("validation returns either `assert_success` or `assert_errors` attribute based on result", {
+test_that("validation returns assert_success or assert_errors attribute based on result", {
   data <- data.frame(
     V1 = c(1, 0),
     V2 = c(-1, -2)

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -16,11 +16,6 @@ test_that("get_assert_method correctly choses assertion method", {
   )
 })
 
-test_that("predicate in get_assert_method expects function returning logical vector or function", {
-  predicate <- function(x) x + 1
-  expect_error(data.validator:::get_assert_method(predicate))
-})
-
 test_that("validate returns expected attributes", {
   data <- data.frame(V1 = c("c", "d"), V2 = c(2, 2), V3 = c(1, 1))
   data <- validate(data, description = "Validation object description test")
@@ -87,15 +82,16 @@ test_that("validate_rows throws a message if there are no columns selected", {
   expect_message(validate_rows(validation, rowSums, function(x) TRUE))
 })
 
-test_that("validate_if correctly handles validation", {
+test_that("validation returns success or error attribute", {
   data <- data.frame(
     V1 = c(1, 0),
     V2 = c(-1, -2)
   )
+  data <- validate(data)
 
   val_success <- validate_if(data, V2 < 0)
   val_error <- validate_if(data, V1 < 0)
 
-  expect_true(success_class %in% names(attributes(val_success)))
+  expect_true("assertr_success" %in% names(attributes(val_success)))
   expect_true("assertr_errors" %in% names(attributes(val_error)))
 })

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -16,6 +16,23 @@ test_that("get_assert_method correctly choses assertion method", {
   )
 })
 
+test_that("predicate in get_assert_method should be a function returning logical vector or function", {
+  fun <- function(x) x + 1
+
+  expect_error(data.validator:::get_assert_method(function(x) x + 1))
+})
+
+test_that("validate returns expected attributes", {
+  data <- data.frame(V1 = c("c", "d"), V2 = c(2, 2), V3 = c(1, 1))
+  data <- validate(data, description = "Validation object description test")
+  attr_names <- names(attributes(data))
+
+  expect_true("data-name" %in% attr_names)
+  expect_true("data-description" %in% attr_names)
+  expect_true("assertr_in_chain_success_fun_override" %in% attr_names)
+  expect_true("assertr_in_chain_error_fun_override" %in% attr_names)
+})
+
 test_that("Validation works even with evaluation error", {
   validation_result <-
     data.validator::validate(iris, name = "Iris wrong column test") %>%
@@ -69,4 +86,17 @@ test_that("validate_rows throws a message if there are no columns selected", {
   validation <- validate(data)
 
   expect_message(validate_rows(validation, rowSums, function(x) TRUE))
+})
+
+test_that("validate_if correctly handles validation", {
+  data <- data.frame(
+    V1 = c(1, 0),
+    V2 = c(-1, -2)
+  )
+
+  val_success <- validate_if(data, V2 < 0)
+  val_error <- validate_if(data, V1 < 0)
+
+  expect_true(success_class %in% names(attributes(val_success)))
+  expect_true("assertr_errors" %in% names(attributes(val_error)))
 })

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -82,7 +82,7 @@ test_that("validate_rows throws a message if there are no columns selected", {
   expect_message(validate_rows(validation, rowSums, function(x) TRUE))
 })
 
-test_that("validation returns success or error attribute", {
+test_that("validation returns either `assert_success` or `assert_errors` attribute based on result", {
   data <- data.frame(
     V1 = c(1, 0),
     V2 = c(-1, -2)

--- a/tests/testthat/test-assertions.R
+++ b/tests/testthat/test-assertions.R
@@ -100,4 +100,3 @@ test_that("validation returns assert_success or assert_errors attribute based on
   expect_true(name_error %in% names(attributes(val_error)))
   expect_false(name_success %in% names(attributes(val_error)))
 })
-

--- a/tests/testthat/test-parsers.R
+++ b/tests/testthat/test-parsers.R
@@ -7,6 +7,7 @@ test_that("parse_errors_to_df parses correct error assertion type", {
   validation <- validate(data) %>%
     validate_if(V1 < 0)
 
+  # `error_id` is coming from `results_parsers.R`
   expect_equal(parse_errors_to_df(validation)$type, error_id)
 })
 
@@ -17,6 +18,7 @@ test_that("parse_successes_to_df parses correct success assertion type", {
   validation <- validate(data) %>%
     validate_rows(rowSums, assertr::in_set(0, 1), V1)
 
+  # `success_id` is coming from `results_parsers.R`
   expect_equal(parse_successes_to_df(validation)$type, success_id)
 })
 

--- a/tests/testthat/test-parsers.R
+++ b/tests/testthat/test-parsers.R
@@ -1,0 +1,25 @@
+test_that("parse_errors_to_df parses correct assertion type and correct error_df", {
+  data <- data.frame(
+    V1 = c(1, 0),
+    V2 = c(-1, -2)
+  )
+  validation <- validate_if(data, V1 < 0)
+  parsed <- parse_errors_to_df(validation)
+
+  expect_equal(parsed$type, error_id)
+  expect_equal(nrow(parsed$error_df[[1]]), sum(!data$V1 < 0))
+})
+
+test_that("parse_successes_to_df parses success correctly", {
+  data <- data.frame(
+    V1 = c(1, 0),
+    V2 = c(-1, -2)
+  )
+  data <- validate_if(data, V2 < 0)
+
+  parsed <- parse_successes_to_df(data)
+
+  expect_true(is.na(parsed$num.violations))
+  expect_equal(parsed$type, success_id)
+  expect_null(parsed$error_df[[1]])
+})

--- a/tests/testthat/test-parsers.R
+++ b/tests/testthat/test-parsers.R
@@ -5,7 +5,7 @@ test_that("parse_errors_to_df parses correct assertion type", {
     V1 = c(1, 0, -3)
   )
   validation <- validate(data) %>%
-    validate_if(V1 < 0) 
+    validate_if(V1 < 0)
 
   expect_equal(parse_errors_to_df(validation)$type, error_id)
 })
@@ -15,7 +15,7 @@ test_that("parse_successes_to_df parses correct assertion type", {
     V1 = c(0, 1, 0)
   )
   validation <- validate(data) %>%
-    validate_rows(rowSums, assertr::in_set(0,1), V1)
+    validate_rows(rowSums, assertr::in_set(0, 1), V1)
 
   expect_equal(parse_successes_to_df(validation)$type, success_id)
 })
@@ -29,4 +29,3 @@ test_that("parse_errors_to_df parses correct number of detected errors", {
 
   expect_equal(nrow(parsed$error_df[[1]]), sum(!data$V1 < 0))
 })
-

--- a/tests/testthat/test-parsers.R
+++ b/tests/testthat/test-parsers.R
@@ -1,6 +1,6 @@
 context("parsers")
 
-test_that("parse_errors_to_df parses correct assertion type", {
+test_that("parse_errors_to_df parses correct error assertion type", {
   data <- data.frame(
     V1 = c(1, 0, -3)
   )
@@ -10,7 +10,7 @@ test_that("parse_errors_to_df parses correct assertion type", {
   expect_equal(parse_errors_to_df(validation)$type, error_id)
 })
 
-test_that("parse_successes_to_df parses correct assertion type", {
+test_that("parse_successes_to_df parses correct success assertion type", {
   data <- data.frame(
     V1 = c(0, 1, 0)
   )

--- a/tests/testthat/test-parsers.R
+++ b/tests/testthat/test-parsers.R
@@ -1,0 +1,26 @@
+test_that("parse_errors_to_df parses correct assertion type and correct error_df", {
+  data <- data.frame(
+    V1 = c(1, 0),
+    V2 = c(-1, -2)
+  )
+  validation <- validate_if(data, V1 < 0)
+  parsed <- parse_errors_to_df(validation)
+
+  expect_equal(parsed$type, error_id)
+  expect_equal(nrow(parsed$error_df[[1]]), sum(!data$V1 < 0))
+})
+
+test_that("parse_successes_to_df parses success correctly", {
+  data <- data.frame(
+    V1 = c(1, 0),
+    V2 = c(-1, -2)
+  )
+  data <- validate_if(data, V2 < 0)
+
+  parsed <- parse_successes_to_df(data)
+
+  expect_true(is.na(parsed$num.violations))
+  expect_equal(parsed$type, success_id)
+  expect_null(parsed$error_df[[1]])
+})
+

--- a/tests/testthat/test-parsers.R
+++ b/tests/testthat/test-parsers.R
@@ -1,25 +1,32 @@
-test_that("parse_errors_to_df parses correct assertion type and correct error_df", {
+context("parsers")
+
+test_that("parse_errors_to_df parses correct assertion type", {
   data <- data.frame(
-    V1 = c(1, 0),
-    V2 = c(-1, -2)
+    V1 = c(1, 0, -3)
+  )
+  validation <- validate(data) %>%
+    validate_if(V1 < 0) 
+
+  expect_equal(parse_errors_to_df(validation)$type, error_id)
+})
+
+test_that("parse_successes_to_df parses correct assertion type", {
+  data <- data.frame(
+    V1 = c(0, 1, 0)
+  )
+  validation <- validate(data) %>%
+    validate_rows(rowSums, assertr::in_set(0,1), V1)
+
+  expect_equal(parse_successes_to_df(validation)$type, success_id)
+})
+
+test_that("parse_errors_to_df parses correct number of detected errors", {
+  data <- data.frame(
+    V1 = c(1, 0, -3)
   )
   validation <- validate_if(data, V1 < 0)
   parsed <- parse_errors_to_df(validation)
 
-  expect_equal(parsed$type, error_id)
   expect_equal(nrow(parsed$error_df[[1]]), sum(!data$V1 < 0))
 })
 
-test_that("parse_successes_to_df parses success correctly", {
-  data <- data.frame(
-    V1 = c(1, 0),
-    V2 = c(-1, -2)
-  )
-  data <- validate_if(data, V2 < 0)
-
-  parsed <- parse_successes_to_df(data)
-
-  expect_true(is.na(parsed$num.violations))
-  expect_equal(parsed$type, success_id)
-  expect_null(parsed$error_df[[1]])
-})


### PR DESCRIPTION
Add unit tests to assertions and parsers:
- `predicate` in `get_assert_method` should be a function returning logical vector or function
- `validate` returns expected attributes
- `validate_if` correctly handles validation
- `parse_errors_to_df` parses correct assertion type and correct error_df
- `parse_successes_to_df` parses success correctly