### PR TITLE
fix: swapped error & warning argument in save_summary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: data.validator
 Type: Package
 Title: Automatic Data Validation and Reporting
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R: c(person("Marcin", "Dubel", email = "opensource+marcin@appsilon.com", role = c("aut", "cre")),
              person("Paweł", "Przytuła", email = "pawel@appsilon.com", role = c("aut")),
              person("Jakub", "Nowicki", email = "kuba@appsilon.com", role = c("aut")),

--- a/R/report.R
+++ b/R/report.R
@@ -8,8 +8,8 @@ Report <- R6Class( #nolint: object_name_linter
       types <- c(success_id, warning_id, error_id)[c(success, warning, error)]
       cat("Validation summary: \n")
       if (success) cat(" Number of successful validations: ", private$n_passed, "\n", sep = "")
-      if (warning) cat(" Number of failed validations: ", private$n_failed, "\n", sep = "")
-      if (error) cat(" Number of validations with warnings: ", private$n_warned, "\n", sep = "")
+      if (warning) cat(" Number of validations with warnings: ", private$n_warned, "\n", sep = "")
+      if (error) cat(" Number of failed validations: ", private$n_failed, "\n", sep = "")
       if (nrow(private$validation_results) > 0) {
         cat("\n")
         cat("Advanced view: \n")


### PR DESCRIPTION
It looks like the arguments passed in `error` and `warning` were swapped in Validation summary resulted from the output:

```
dat <- data.frame(
        V1 = c(1, 2, 3),
        V2 = c("a", "b", "c")
    )
report <- data_validation_report()
validation <- validate(dat) |>
        validate_cols(is.numeric) |>
        validate_if(V1 > 0) |>
        add_results(report)

save_summary(report, success = F, warning = F, error = T)  # Presents "Number of validations with warnings"
save_summary(report, success = F, warning = T, error = F)  # Presents "Number of failed validations"
```

