### PR TITLE
Fix: remove head error table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: data.validator
 Type: Package
 Title: Automatic Data Validation and Reporting
-Version: 0.2.0.9002
+Version: 0.2.0.9003
 Authors@R: c(person("Marcin", "Dubel", email = "opensource+marcin@appsilon.com", role = c("aut", "cre")),
              person("Paweł", "Przytuła", email = "pawel@appsilon.com", role = c("aut")),
              person("Jakub", "Nowicki", email = "kuba@appsilon.com", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 - Fixed `validate()` function to correctly return `data-name` attribute when used in pipe chains with `%>%` or `|>` operator.
 - `save_results()` now uses function passed to `method` argument to write results
 
+# data.validator 0.2.1
+
+- Bug fix for error table in modal that returned up to 6 rows. Now it returns full data frame.
+
 # data.validator 0.2.0
 
 - `validate_cols()` and `validate_rows()` will use all columns in dataframe if no column is passed

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,7 @@
 - Swapping of `error` and `warning` arguments in `save_summary()` fixed
 - Fixed `validate()` function to correctly return `data-name` attribute when used in pipe chains with `%>%` or `|>` operator.
 - `save_results()` now uses function passed to `method` argument to write results
-
-# data.validator 0.2.1
-
-- Bug fix for error table in modal that returned up to 6 rows. Now it returns full data frame.
+- Bug fix for error table in modal that always returns up to 6 rows. Now it may return full data frame.
 
 # data.validator 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 - Swapping of `error` and `warning` arguments in `save_summary()` fixed
 - Fixed `validate()` function to correctly return `data-name` attribute when used in pipe chains with `%>%` or `|>` operator.
 - `save_results()` now uses function passed to `method` argument to write results
-- Bug fix for error table in modal that always returns up to 6 rows. Now it may return full data frame.
+- Enable the option to change the size of the sample of errors displayed in `render_semantic_report_ui`.
 
 # data.validator 0.2.0
 

--- a/R/report.R
+++ b/R/report.R
@@ -174,6 +174,7 @@ save_results <- function(report, file_name = "results.csv", method = utils::writ
 #'   \code{data.validator} rmarkdown template to see basic construction - the one is used as a
 #'   default template.
 #' @param ... Additional parameters passed to \code{ui_constructor}.
+#' For example: \code{df_error_head_n}
 #' @export
 save_report <- function(report,
                         output_file = "validation_report.html",

--- a/R/semantic_report_constructors.R
+++ b/R/semantic_report_constructors.R
@@ -187,7 +187,15 @@ make_accordion_container <- function(...) {
 #' @param df_error_head_n Number of rows to display in error table.
 #' @return Accordion.
 #' @keywords internal
-make_accordion_element <- function(results, color = "green", label, active = FALSE, type, mark, df_error_head_n) {
+make_accordion_element <- function(
+    results,
+    color = "green",
+    label,
+    active = FALSE,
+    type,
+    mark,
+    df_error_head_n
+  ) {
   state <- NULL
   if (active) {
     state <- "active"
@@ -204,7 +212,10 @@ make_accordion_element <- function(results, color = "green", label, active = FAL
         label
       )
     ),
-    htmltools::div(class = paste("content", state), result_table(results, type, mark, df_error_head_n))
+    htmltools::div(
+      class = paste("content", state),
+      result_table(results, type, mark, df_error_head_n)
+    )
   )
 }
 
@@ -334,7 +345,13 @@ make_summary_table <- function(n_passes, n_fails, n_warns) {
 #' @param df_error_head_n Number of rows to display in error table.
 #' @return HTML validation report.
 #' @keywords internal
-get_semantic_report_ui <- function(n_passes, n_fails, n_warns, validation_results, df_error_head_n) {
+get_semantic_report_ui <- function(
+    n_passes,
+    n_fails,
+    n_warns,
+    validation_results,
+    df_error_head_n
+  ) {
   summary_table <- make_summary_table(n_passes, n_fails, n_warns)
   unique_objects <- validation_results %>% dplyr::pull(.data$table_name) %>% unique()
   html_report <- unique_objects %>% purrr::map(~ {
@@ -366,7 +383,8 @@ post_render_js <- "
 #' @param success Should success results be presented?
 #' @param warning Should warning results be presented?
 #' @param error Should error results be presented?
-#' @param df_error_head_n Number of rows to display in error table. Works in the same way as \code{head} function.
+#' @param df_error_head_n Number of rows to display in error table.
+#' Works in the same way as \code{head} function.
 #' @export
 render_semantic_report_ui <- function(validation_results,
                                       success = TRUE,

--- a/R/semantic_report_constructors.R
+++ b/R/semantic_report_constructors.R
@@ -16,9 +16,10 @@ segment <- function(title, ...) {
 #' Prepare modal content.
 #' @description Prepare modal content.
 #' @param error Assertr error.
+#' @param df_error_head_n Number of rows to display in error table.
 #' @return Modal content.
 #' @keywords internal
-prepare_modal_content <- function(error) {
+prepare_modal_content <- function(error, df_error_head_n) {
   data_part <- NULL #nolint: object_usage_linter
   errors_number <- seq_along(error$error_df[[1]])
   purrr::map(errors_number, ~ {
@@ -28,7 +29,7 @@ prepare_modal_content <- function(error) {
         htmltools::div(class = "ui header", "Violated data (sample)"),
         htmltools::HTML(
           knitr::kable(
-            error$error_df[[1]][[.x]],
+            utils::head(error$error_df[[1]][[.x]], n = df_error_head_n),
             "html",
             align = NULL,
             table.attr = "class=\"ui cellable table\""
@@ -66,11 +67,12 @@ prepare_modal_content <- function(error) {
 #' @param results Results to display in a row.
 #' @param type Result type.
 #' @param mark Icon to display.
+#' @param df_error_head_n Number of rows to display in error table.
 #' @return Table row.
 #' @importFrom dplyr %>%
 #' @importFrom rlang .data
 #' @keywords internal
-make_table_row <- function(results, type, mark) {
+make_table_row <- function(results, type, mark, df_error_head_n) {
   description <- results %>% dplyr::pull(.data$description)
   id <- results %>% dplyr::pull(.data$assertion.id)
   data_name <- results %>% dplyr::pull(.data$table_name)
@@ -92,7 +94,7 @@ make_table_row <- function(results, type, mark) {
         htmltools::div(
           class = "description",
           htmltools::tagList(
-            prepare_modal_content(results)
+            prepare_modal_content(results, df_error_head_n)
           )
         )
       )
@@ -123,9 +125,10 @@ make_table_row <- function(results, type, mark) {
 #' @param results Result to display in table.
 #' @param type Result type.
 #' @param mark Icon to display.
+#' @param df_error_head_n Number of rows to display in error table.
 #' @return Table row.
 #' @keywords internal
-result_table <- function(results, type, mark) {
+result_table <- function(results, type, mark, df_error_head_n) {
   if (nrow(results) == 0) {
     "No cases to display."
   } else {
@@ -147,7 +150,15 @@ result_table <- function(results, type, mark) {
         )
       ),
       htmltools::tags$tbody(
-        purrr::map(1:nrow(results), ~ make_table_row(results[.x, ], type, mark)) #nolint: seq_linter
+        purrr::map(
+          seq_len(nrow(results)),
+          ~ make_table_row(
+              results[.x, ],
+              type,
+              mark,
+              df_error_head_n = df_error_head_n
+            )
+          )
       )
     )
   }
@@ -173,9 +184,10 @@ make_accordion_container <- function(...) {
 #' @param color Color of the label icon.
 #' @param type Result type.
 #' @param active Is active?
+#' @param df_error_head_n Number of rows to display in error table.
 #' @return Accordion.
 #' @keywords internal
-make_accordion_element <- function(results, color = "green", label, active = FALSE, type, mark) {
+make_accordion_element <- function(results, color = "green", label, active = FALSE, type, mark, df_error_head_n) {
   state <- NULL
   if (active) {
     state <- "active"
@@ -192,7 +204,7 @@ make_accordion_element <- function(results, color = "green", label, active = FAL
         label
       )
     ),
-    htmltools::div(class = paste("content", state), result_table(results, type, mark))
+    htmltools::div(class = paste("content", state), result_table(results, type, mark, df_error_head_n))
   )
 }
 
@@ -202,9 +214,10 @@ make_accordion_element <- function(results, color = "green", label, active = FAL
 #' @param n_passes Number of successful assertions.
 #' @param n_fails Number of warning assertions.
 #' @param n_warns Number of violation assertions.
+#' @param df_error_head_n Number of rows to display in error table.
 #' @return Validation report.
 #' @keywords internal
-display_results <- function(data, n_passes, n_fails, n_warns) {
+display_results <- function(data, n_passes, n_fails, n_warns, df_error_head_n) {
   data_name <- data$table_name[1]
   results_failed <- data %>%
     dplyr::filter(.data$type == error_id)
@@ -235,7 +248,8 @@ display_results <- function(data, n_passes, n_fails, n_warns) {
           label = "Failed",
           mark = "red big remove",
           type = error_id,
-          active = is_negative_active
+          active = is_negative_active,
+          df_error_head_n = df_error_head_n
         ),
       if (!is.null(n_warns))
         make_accordion_element(
@@ -317,15 +331,16 @@ make_summary_table <- function(n_passes, n_fails, n_warns) {
 #' @param n_fails Number of failed validations.
 #' @param n_warns Number of warnings.
 #' @param validation_results Data frame with validation results.
+#' @param df_error_head_n Number of rows to display in error table.
 #' @return HTML validation report.
 #' @keywords internal
-get_semantic_report_ui <- function(n_passes, n_fails, n_warns, validation_results) {
+get_semantic_report_ui <- function(n_passes, n_fails, n_warns, validation_results, df_error_head_n = 6L) {
   summary_table <- make_summary_table(n_passes, n_fails, n_warns)
   unique_objects <- validation_results %>% dplyr::pull(.data$table_name) %>% unique()
   html_report <- unique_objects %>% purrr::map(~ {
     validation_results %>%
       dplyr::filter(.data$table_name == .x) %>%
-      display_results(n_passes, n_fails, n_warns)
+      display_results(n_passes, n_fails, n_warns, df_error_head_n)
   }) %>%
     htmltools::div()
 
@@ -351,11 +366,13 @@ post_render_js <- "
 #' @param success Should success results be presented?
 #' @param warning Should warning results be presented?
 #' @param error Should error results be presented?
+#' @param df_error_head_n Number of rows to display in error table. Works in the same way as \code{head} function.
 #' @export
 render_semantic_report_ui <- function(validation_results,
                                       success = TRUE,
                                       warning = TRUE,
-                                      error = TRUE) {
+                                      error = TRUE,
+                                      df_error_head_n = 6L) {
   n_passes <- NULL
   n_fails <- NULL
   n_warns <- NULL
@@ -372,7 +389,8 @@ render_semantic_report_ui <- function(validation_results,
     n_passes,
     n_fails,
     n_warns,
-    validation_results
+    validation_results,
+    df_error_head_n
   ) %>%
     shiny.semantic::uirender(width = "100%", height = "100%") %>%
     htmlwidgets::onRender(post_render_js)

--- a/R/semantic_report_constructors.R
+++ b/R/semantic_report_constructors.R
@@ -334,7 +334,7 @@ make_summary_table <- function(n_passes, n_fails, n_warns) {
 #' @param df_error_head_n Number of rows to display in error table.
 #' @return HTML validation report.
 #' @keywords internal
-get_semantic_report_ui <- function(n_passes, n_fails, n_warns, validation_results, df_error_head_n = 6L) {
+get_semantic_report_ui <- function(n_passes, n_fails, n_warns, validation_results, df_error_head_n) {
   summary_table <- make_summary_table(n_passes, n_fails, n_warns)
   unique_objects <- validation_results %>% dplyr::pull(.data$table_name) %>% unique()
   html_report <- unique_objects %>% purrr::map(~ {

--- a/R/semantic_report_constructors.R
+++ b/R/semantic_report_constructors.R
@@ -153,12 +153,12 @@ result_table <- function(results, type, mark, df_error_head_n) {
         purrr::map(
           seq_len(nrow(results)),
           ~ make_table_row(
-              results[.x, ],
-              type,
-              mark,
-              df_error_head_n = df_error_head_n
-            )
+            results[.x, ],
+            type,
+            mark,
+            df_error_head_n = df_error_head_n
           )
+        )
       )
     )
   }
@@ -188,14 +188,14 @@ make_accordion_container <- function(...) {
 #' @return Accordion.
 #' @keywords internal
 make_accordion_element <- function(
-    results,
-    color = "green",
-    label,
-    active = FALSE,
-    type,
-    mark,
-    df_error_head_n
-  ) {
+  results,
+  color = "green",
+  label,
+  active = FALSE,
+  type,
+  mark,
+  df_error_head_n
+) {
   state <- NULL
   if (active) {
     state <- "active"
@@ -346,12 +346,12 @@ make_summary_table <- function(n_passes, n_fails, n_warns) {
 #' @return HTML validation report.
 #' @keywords internal
 get_semantic_report_ui <- function(
-    n_passes,
-    n_fails,
-    n_warns,
-    validation_results,
-    df_error_head_n
-  ) {
+  n_passes,
+  n_fails,
+  n_warns,
+  validation_results,
+  df_error_head_n
+) {
   summary_table <- make_summary_table(n_passes, n_fails, n_warns)
   unique_objects <- validation_results %>% dplyr::pull(.data$table_name) %>% unique()
   html_report <- unique_objects %>% purrr::map(~ {

--- a/R/semantic_report_constructors.R
+++ b/R/semantic_report_constructors.R
@@ -28,7 +28,7 @@ prepare_modal_content <- function(error) {
         htmltools::div(class = "ui header", "Violated data (sample)"),
         htmltools::HTML(
           knitr::kable(
-            utils::head(error$error_df[[1]][[.x]]),
+            error$error_df[[1]][[.x]],
             "html",
             align = NULL,
             table.attr = "class=\"ui cellable table\""

--- a/man/display_results.Rd
+++ b/man/display_results.Rd
@@ -4,7 +4,7 @@
 \alias{display_results}
 \title{Displays results of validations.}
 \usage{
-display_results(data, n_passes, n_fails, n_warns)
+display_results(data, n_passes, n_fails, n_warns, df_error_head_n)
 }
 \arguments{
 \item{data}{Report data.}
@@ -14,6 +14,8 @@ display_results(data, n_passes, n_fails, n_warns)
 \item{n_fails}{Number of warning assertions.}
 
 \item{n_warns}{Number of violation assertions.}
+
+\item{df_error_head_n}{Number of rows to display in error table.}
 }
 \value{
 Validation report.

--- a/man/get_semantic_report_ui.Rd
+++ b/man/get_semantic_report_ui.Rd
@@ -9,7 +9,7 @@ get_semantic_report_ui(
   n_fails,
   n_warns,
   validation_results,
-  df_error_head_n = 6L
+  df_error_head_n
 )
 }
 \arguments{

--- a/man/get_semantic_report_ui.Rd
+++ b/man/get_semantic_report_ui.Rd
@@ -4,7 +4,13 @@
 \alias{get_semantic_report_ui}
 \title{Generate HTML report.}
 \usage{
-get_semantic_report_ui(n_passes, n_fails, n_warns, validation_results)
+get_semantic_report_ui(
+  n_passes,
+  n_fails,
+  n_warns,
+  validation_results,
+  df_error_head_n = 6L
+)
 }
 \arguments{
 \item{n_passes}{Number of passed validations}
@@ -14,6 +20,8 @@ get_semantic_report_ui(n_passes, n_fails, n_warns, validation_results)
 \item{n_warns}{Number of warnings.}
 
 \item{validation_results}{Data frame with validation results.}
+
+\item{df_error_head_n}{Number of rows to display in error table.}
 }
 \value{
 HTML validation report.

--- a/man/make_accordion_element.Rd
+++ b/man/make_accordion_element.Rd
@@ -10,7 +10,8 @@ make_accordion_element(
   label,
   active = FALSE,
   type,
-  mark
+  mark,
+  df_error_head_n
 )
 }
 \arguments{
@@ -25,6 +26,8 @@ make_accordion_element(
 \item{type}{Result type.}
 
 \item{mark}{Icon to display.}
+
+\item{df_error_head_n}{Number of rows to display in error table.}
 }
 \value{
 Accordion.

--- a/man/make_table_row.Rd
+++ b/man/make_table_row.Rd
@@ -4,7 +4,7 @@
 \alias{make_table_row}
 \title{Create table row.}
 \usage{
-make_table_row(results, type, mark)
+make_table_row(results, type, mark, df_error_head_n)
 }
 \arguments{
 \item{results}{Results to display in a row.}
@@ -12,6 +12,8 @@ make_table_row(results, type, mark)
 \item{type}{Result type.}
 
 \item{mark}{Icon to display.}
+
+\item{df_error_head_n}{Number of rows to display in error table.}
 }
 \value{
 Table row.

--- a/man/prepare_modal_content.Rd
+++ b/man/prepare_modal_content.Rd
@@ -4,10 +4,12 @@
 \alias{prepare_modal_content}
 \title{Prepare modal content.}
 \usage{
-prepare_modal_content(error)
+prepare_modal_content(error, df_error_head_n)
 }
 \arguments{
 \item{error}{Assertr error.}
+
+\item{df_error_head_n}{Number of rows to display in error table.}
 }
 \value{
 Modal content.

--- a/man/render_semantic_report_ui.Rd
+++ b/man/render_semantic_report_ui.Rd
@@ -8,7 +8,8 @@ render_semantic_report_ui(
   validation_results,
   success = TRUE,
   warning = TRUE,
-  error = TRUE
+  error = TRUE,
+  df_error_head_n = 6L
 )
 }
 \arguments{
@@ -19,6 +20,8 @@ render_semantic_report_ui(
 \item{warning}{Should warning results be presented?}
 
 \item{error}{Should error results be presented?}
+
+\item{df_error_head_n}{Number of rows to display in error table. Works in the same way as \code{head} function.}
 }
 \description{
 Renders content of semantic report version.

--- a/man/render_semantic_report_ui.Rd
+++ b/man/render_semantic_report_ui.Rd
@@ -21,7 +21,8 @@ render_semantic_report_ui(
 
 \item{error}{Should error results be presented?}
 
-\item{df_error_head_n}{Number of rows to display in error table. Works in the same way as \code{head} function.}
+\item{df_error_head_n}{Number of rows to display in error table.
+Works in the same way as \code{head} function.}
 }
 \description{
 Renders content of semantic report version.

--- a/man/result_table.Rd
+++ b/man/result_table.Rd
@@ -4,7 +4,7 @@
 \alias{result_table}
 \title{Create table with results.}
 \usage{
-result_table(results, type, mark)
+result_table(results, type, mark, df_error_head_n)
 }
 \arguments{
 \item{results}{Result to display in table.}
@@ -12,6 +12,8 @@ result_table(results, type, mark)
 \item{type}{Result type.}
 
 \item{mark}{Icon to display.}
+
+\item{df_error_head_n}{Number of rows to display in error table.}
 }
 \value{
 Table row.

--- a/man/save_report.Rd
+++ b/man/save_report.Rd
@@ -29,7 +29,8 @@ generates HTML code or HTML widget that should be used to generate report conten
 \code{data.validator} rmarkdown template to see basic construction - the one is used as a
 default template.}
 
-\item{...}{Additional parameters passed to \code{ui_constructor}.}
+\item{...}{Additional parameters passed to \code{ui_constructor}.
+For example: \code{df_error_head_n}}
 }
 \description{
 Saving results as a HTML report

--- a/tests/testthat/test-report_constructors.R
+++ b/tests/testthat/test-report_constructors.R
@@ -81,7 +81,7 @@ test_that("make_accordion_container() generates ui with 'ui styled accordion' cl
 
 test_that("prepare_modal_content() includes results' error message", {
   results  <- results_test()
-  ui <- prepare_modal_content(results)
+  ui <- prepare_modal_content(results, df_error_head_n = 6L)
 
   tagq <- tagQuery(ui)
   tags <- tagq$find("td")$selectedTags()
@@ -93,7 +93,7 @@ test_that("make_table_row() creates a table row tag", {
   results_passed <- results_test() %>%
     dplyr::filter(.data$type == success_id)
 
-  ui <- make_table_row(results_passed, mark = mark_success, type = success_id)
+  ui <- make_table_row(results_passed, mark = mark_success, type = success_id, df_error_head_n = 6L)
   ui <- as.character(ui)
 
   expect_true(startsWith(ui, "<tr>"))
@@ -104,7 +104,7 @@ test_that("make_table_row() generates modal content for results with failed vali
   results_failed <- results_test() %>%
     dplyr::filter(.data$type == error_id)
 
-  ui <- make_table_row(results_failed, mark = mark_failed, type = error_id)
+  ui <- make_table_row(results_failed, mark = mark_failed, type = error_id, df_error_head_n = 6L)
 
   tagq <- tagQuery(ui)
   tags <- tagq$
@@ -119,7 +119,7 @@ test_that("make_table_row() generates modal content for results with failed vali
     gsub("\\s", "", .)
 
 
-  modal <- prepare_modal_content(results_failed) %>%
+  modal <- prepare_modal_content(results_failed, df_error_head_n = 6L) %>%
     as.character() %>%
     gsub("\\s", "", .)
 


### PR DESCRIPTION
### Issue #88 

Before submitting a PR please answer:
* Was it necessary to update README? Is README updated?
* Are unit tests added for new logic?

### Changes:
- `df_error_head_n` variable added to control nrow for error data.frame